### PR TITLE
Changes to beginendblock-panic query

### DIFF
--- a/src/beginendblock-panic.ql
+++ b/src/beginendblock-panic.ql
@@ -17,21 +17,13 @@ predicate isBeginOrEndBlock(string funName) {
   funName = "EndBlocker"
 }
 
-predicate isLikelyFalsePositive(Function f) {
-  // these could potentially lead to false negatives
-  // but otherwise, there are hundreds of findings
-  f.getName()
-      .regexpMatch("(BeginBlock(er)?|EndBlock(er)?" +
-          "|Logger|Now|NewAttribute|Error|Info|With|.*Event" +
-          "|GetVotes|String|BlockHeight|NewCoins|MsgTypeURL|Listen" +
-          "|CacheContext|ModuleSetGauge|BlockHeader|getMaximumBlockGas" +
-          "|Sprintf|ModuleMeasureSince|.*Params|.*Tracing|.*GasMeter).*")
-}
 
 predicate isIrrelevantPackage(string packageName) {
   // for normal cases, panics to cause chain halts are desired in crisis or upgrade
   // (but there may be unwanted cases, i.e. false negatives)
-  packageName = "crisis" or packageName = "upgrade" or packageName = "mocks"
+  packageName = "crisis" or 
+  packageName = "upgrade" or 
+  packageName = "mocks"
 }
 
 
@@ -59,7 +51,6 @@ where
   sourceCall = panicCall.getParentCallNode*() and
 
   isBeginOrEndBlock(sourceCall.getEnclosingCallable().getName()) and
-  not isLikelyFalsePositive(panicCall.getTarget()) and
   not isIrrelevantPackage(panicCall.getFile().getPackageName()) and
   // explicit comment explaining why it is safe
   // TODO: extract to a common predicate or a class

--- a/src/beginendblock-panic.ql
+++ b/src/beginendblock-panic.ql
@@ -34,20 +34,42 @@ predicate isIrrelevantPackage(string packageName) {
   packageName = "crisis" or packageName = "upgrade" or packageName = "mocks"
 }
 
-from CallExpr panicCall
+
+class CallNodeWithFamily extends DataFlow::CallNode, DataFlow::Node  {
+
+  CallNodeWithFamily() {
+    this instanceof DataFlow::CallNode
+  }
+ 
+  DataFlow::CallNode getParentCallNode (){
+    result.getACallee() = this.getRoot()
+  }  
+}
+
+
+/* This query looks for all calls to panic that originated from EndBlock or BeginBlock
+(as defined by the isBeginOrEndBlock predicate).
+It excludes potential false-positives (as defined by isLikelyFalsePositive predicate) 
+and those stemming from irrelevant packages (as defined by isIrrelevantPackage predicate).
+It also exludes panics which are preceded by a comment containing the string "SAFE:".
+*/
+from CallNodeWithFamily panicCall, CallNodeWithFamily sourceCall
 where
-  panicCall.getTarget().mayPanic() and
-  isBeginOrEndBlock(panicCall.getParent*().getEnclosingFunction().getName()) and
+  panicCall.getTarget().mustPanic() and
+  sourceCall = panicCall.getParentCallNode*() and
+
+  isBeginOrEndBlock(sourceCall.getEnclosingCallable().getName()) and
   not isLikelyFalsePositive(panicCall.getTarget()) and
   not isIrrelevantPackage(panicCall.getFile().getPackageName()) and
   // explicit comment explaining why it is safe
   // TODO: extract to a common predicate or a class
   not exists(CommentGroup c |
-    panicCall.getLocation().getStartLine() - 1 = c.getLocation().getStartLine() or
-    panicCall.getEnclosingFunction().getLocation().getStartLine() - 1 =
+    panicCall.asExpr().getLocation().getStartLine() - 1 = c.getLocation().getStartLine() or
+    panicCall.asExpr().getEnclosingFunction().getLocation().getStartLine() - 1 =
       c.getLocation().getStartLine()
   |
     c.getAComment().getText().matches("%SAFE:%")
   )
 select panicCall,
   "Possible panics in BeginBock- or EndBlock-related consensus methods could cause a chain halt"
+  

--- a/src/path-beginendblock-panic.ql
+++ b/src/path-beginendblock-panic.ql
@@ -1,0 +1,66 @@
+/**
+ * @name Panic in BeginBock or EndBlock consensus methods
+ * @description Panics in BeginBlocker and EndBlocker could cause a chain halt: https://docs.cosmos.network/master/building-modules/beginblock-endblock.html
+ * @kind path-problem
+ * @problem.severity warning
+ * @id crypto-com/cosmos-sdk-codeql/beginendblock-panic
+ * @tags correctness
+ */
+
+import go
+
+predicate isBeginOrEndBlock(string funName) {
+  // TODO: make it more precise to check if it's from Keeper or ABCI interface
+  funName = "BeginBlock" or
+  funName = "EndBlock" or
+  funName = "BeginBlocker" or
+  funName = "EndBlocker"
+}
+
+
+predicate isIrrelevantPackage(string packageName) {
+  // for normal cases, panics to cause chain halts are desired in crisis or upgrade
+  // (but there may be unwanted cases, i.e. false negatives)
+  packageName = "crisis" or 
+  packageName = "upgrade" or 
+  packageName = "mocks"
+}
+
+
+class CallNodeWithFamily extends DataFlow::CallNode, DataFlow::Node  {
+
+  CallNodeWithFamily() {
+    this instanceof DataFlow::CallNode
+  }
+ 
+  DataFlow::CallNode getChildCallNode(){    
+    this.getACallee() = result.getRoot()
+  }  
+
+}
+
+query predicate edges (CallNodeWithFamily a, CallNodeWithFamily b) 
+ { a.getChildCallNode() = b }
+
+
+/* This query looks for all function call paths  originating from EndBlock or BeginBlock
+(as defined by the isBeginOrEndBlock predicate) and ending in a panic.
+It excludes irrelevant packages (as defined by isIrrelevantPackage predicate).
+It also exludes panics which are preceded by a comment containing the string "SAFE:".
+*/
+from CallNodeWithFamily panicCall, CallNodeWithFamily sourceCall
+where
+  panicCall.getTarget().mustPanic() and
+  edges*(sourceCall, panicCall) and
+  isBeginOrEndBlock(sourceCall.getEnclosingCallable().getName()) and
+  not isIrrelevantPackage(panicCall.getFile().getPackageName()) and
+  // explicit comment explaining why it is safe
+  // TODO: extract to a common predicate or a class
+  not exists(CommentGroup c |
+    panicCall.asExpr().getLocation().getStartLine() - 1 = c.getLocation().getStartLine() or
+    panicCall.asExpr().getEnclosingFunction().getLocation().getStartLine() - 1 =
+      c.getLocation().getStartLine()
+  |
+    c.getAComment().getText().matches("%SAFE:%")
+  )
+select sourceCall, sourceCall, panicCall, "path flow from Begin/EndBlock to a panic call"


### PR DESCRIPTION
Connected to the question in the issue #3, in this PR I changed two things:
1. replaced the `mayPanic()` with `mustPanic()`
2. Changed the way parent-child relation was modelled