### PR TITLE
feat: update system-time rule to not trigger on `time.Now().Round(0).UTC()`

### DIFF
--- a/src/system-time.ql
+++ b/src/system-time.ql
@@ -16,6 +16,8 @@ predicate isIrrelevantPackage(string packageName) {
 from CallExpr call
 where
   call.getTarget().getQualifiedName() = "time.Now" and
+  not call.getParent().(CallExpr).getTarget().getQualifiedName() = "Round" and
+  not call.getParent*().(CallExpr).getTarget().getQualifiedName() = "UTC" and
   // string formatting is usually a false positive (used in logging etc.),
   // so it's usually ok to ignore.
   // but there could be false negatives (if the string formatting output is written to a consensus state)
@@ -46,4 +48,5 @@ where
   |
     c.getAComment().getText().matches("%SAFE:%")
   )
-select call, "Calling the system time may be a possible source of non-determinism"
+select call,
+  "Calling the system time may be a possible source of non-determinism. Use time.Now().Round(0).UTC() instead."


### PR DESCRIPTION
ref: https://github.com/cosmos/cosmos-sdk/pull/18239#discussion_r1376005648

I am not too familiar with CodeQL expression, so I have used GitHub Copilot to help me.